### PR TITLE
New syntax for site.conf and rename mesh→ibss

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -11,38 +11,38 @@
 	regdom = 'DE',
 
 	wifi24 = {
-        channel = 1,
-        htmode = 'HT40+',
-        ap = {  
-	        ssid = 'braunschweig.freifunk.net',
-        },
-        ibss = {
-            ssid = '02:d1:11:37:fc:38',
-            bssid = '02:d1:11:37:fc:38',
-            mcast_rate = 12000,
-        },
-        mesh = {
-            id = 'ffbs-mesh',
-            mcast_rate = 12000,
-            disabled = true,
-        },
+		channel = 1,
+		htmode = 'HT40+',
+		ap = {  
+			ssid = 'braunschweig.freifunk.net',
+		},
+		ibss = {
+			ssid = '02:d1:11:37:fc:38',
+			bssid = '02:d1:11:37:fc:38',
+			mcast_rate = 12000,
+		},
+		mesh = {
+			id = 'ffbs-mesh',
+			mcast_rate = 12000,
+			disabled = true,
+		},
 	},
 	wifi5 = {
 		channel = 44,
 		htmode = 'HT40+',
-        ap = {
-    		ssid = 'braunschweig.freifunk.net (5GHz)',
-        },
-        ibss = {
-		    ssid = '02:d1:11:37:fc:38',
-		    bssid = '02:d1:11:37:fc:38',
-		    mcast_rate = 12000,
-        },
-        mesh = {
-            id = 'ffbs-mesh',
-            mcast_rate = 12000,
-            disabled = true,
-        },
+		ap = {
+			ssid = 'braunschweig.freifunk.net (5GHz)',
+		},
+		ibss = {
+			ssid = '02:d1:11:37:fc:38',
+			bssid = '02:d1:11:37:fc:38',
+			mcast_rate = 12000,
+		},
+		mesh = {
+			id = 'ffbs-mesh',
+			mcast_rate = 12000,
+			disabled = true,
+		},
 	},
 
 	next_node = {
@@ -121,13 +121,13 @@
 	},
 
 	legacy = {
-	       version_files = {'/etc/.freifunk_version_keep', '/etc/.lff_version_keep'},
-	       old_files = {'/etc/config/config_mode', '/etc/config/ffbs', '/etc/config/freifunk'},
+		version_files = {'/etc/.freifunk_version_keep', '/etc/.lff_version_keep'},
+		old_files = {'/etc/config/config_mode', '/etc/config/ffbs', '/etc/config/freifunk'},
 
-	       config_mode_configs = {'config_mode', 'ffbs', 'freifunk'},
-	       fastd_configs = {'ffbs_mesh_vpn', 'mesh_vpn'},
-	       mesh_ifname = 'freifunk',
-	       tc_configs = {'ffbs', 'freifunk'},
-	       wifi_names = {'wifi_freifunk', 'wifi_freifunk5', 'wifi_mesh', 'wifi_mesh5'},
+		config_mode_configs = {'config_mode', 'ffbs', 'freifunk'},
+		fastd_configs = {'ffbs_mesh_vpn', 'mesh_vpn'},
+		mesh_ifname = 'freifunk',
+		tc_configs = {'ffbs', 'freifunk'},
+		wifi_names = {'wifi_freifunk', 'wifi_freifunk5', 'wifi_mesh', 'wifi_mesh5'},
 	},
 }

--- a/site.conf
+++ b/site.conf
@@ -11,20 +11,38 @@
 	regdom = 'DE',
 
 	wifi24 = {
-		channel = 1,
-		htmode = 'HT40+',
-		ssid = 'braunschweig.freifunk.net',
-		mesh_ssid = '02:d1:11:37:fc:38',
-		mesh_bssid = '02:d1:11:37:fc:38',
-		mesh_mcast_rate = 12000,
+        channel = 1,
+        htmode = 'HT40+',
+        ap = {  
+	        ssid = 'braunschweig.freifunk.net',
+        },
+        ibss = {
+            ssid = '02:d1:11:37:fc:38',
+            bssid = '02:d1:11:37:fc:38',
+            mcast_rate = 12000,
+        },
+        mesh = {
+            id = 'ffbs-mesh',
+            mcast_rate = 12000,
+            disabled = true,
+        },
 	},
 	wifi5 = {
 		channel = 44,
 		htmode = 'HT40+',
-		ssid = 'braunschweig.freifunk.net (5GHz)',
-		mesh_ssid = '02:d1:11:37:fc:38',
-		mesh_bssid = '02:d1:11:37:fc:38',
-		mesh_mcast_rate = 12000,
+        ap = {
+    		ssid = 'braunschweig.freifunk.net (5GHz)',
+        },
+        ibss = {
+		    ssid = '02:d1:11:37:fc:38',
+		    bssid = '02:d1:11:37:fc:38',
+		    mcast_rate = 12000,
+        },
+        mesh = {
+            id = 'ffbs-mesh',
+            mcast_rate = 12000,
+            disabled = true,
+        },
 	},
 
 	next_node = {


### PR DESCRIPTION
To build with the current master tree another type of syntax is needed in site.conf and also a new type of mashing is introduced which I disabled here to stay with the other nodes.
